### PR TITLE
Specialised keyword handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "epydeck"
 authors = [
-        {name = "Peter Hill", email = "peter.hill@york.ac.uk"}
+        {name = "Peter Hill", email = "peter.hill@york.ac.uk"},
+        {name = "Joel Adams", email = "joel.adams@york.ac.uk"}
 ]
 license = {text = "BSD"}
 requires-python = ">=3.9"

--- a/src/epydeck/__init__.py
+++ b/src/epydeck/__init__.py
@@ -49,7 +49,7 @@ def _parse_block(line: str, fh: TextIOBase) -> dict:
             break
 
         # Handle special keywords
-        if any(line.lower().startswith(keyword + ":") for keyword in special_keywords):
+        if any(line.lower().startswith(f"{keyword}:") for keyword in special_keywords):
             separator = ":"
         else:
             separator = "="

--- a/src/epydeck/__init__.py
+++ b/src/epydeck/__init__.py
@@ -2,6 +2,8 @@ from ast import literal_eval
 from io import TextIOBase, StringIO
 from collections import defaultdict
 
+# Specific deck keywords that use : instead of =
+special_keywords = ["include_species", "identify"]
 
 def _strip_comment(line: str) -> str:
     """Remove comments from line"""
@@ -47,7 +49,7 @@ def _parse_block(line: str, fh: TextIOBase) -> dict:
             break
 
         # Handle special keywords
-        if line.lower().startswith("include_species:"):
+        if any(line.lower().startswith(keyword) for keyword in special_keywords):
             separator = ":"
         else:
             separator = "="
@@ -107,7 +109,7 @@ def loads(text: str) -> dict:
 
 
 def _dump_line(fh: TextIOBase, key: str, value):
-    separator = ":" if key == "include_species" else " ="
+    separator = ":" if key in special_keywords else " ="
     if isinstance(value, bool):
         value = "T" if value else "F"
     fh.write(f"  {key}{separator} {value}\n")

--- a/src/epydeck/__init__.py
+++ b/src/epydeck/__init__.py
@@ -49,7 +49,7 @@ def _parse_block(line: str, fh: TextIOBase) -> dict:
             break
 
         # Handle special keywords
-        if any(line.lower().startswith(keyword) for keyword in special_keywords):
+        if any(line.lower().startswith(keyword + ":") for keyword in special_keywords):
             separator = ":"
         else:
             separator = "="

--- a/src/epydeck/__init__.py
+++ b/src/epydeck/__init__.py
@@ -109,10 +109,10 @@ def loads(text: str) -> dict:
 
 
 def _dump_line(fh: TextIOBase, key: str, value):
-    separator = ":" if key in special_keywords else " ="
+    separator = ":" if key in special_keywords else " = "
     if isinstance(value, bool):
         value = "T" if value else "F"
-    fh.write(f"  {key}{separator} {value}\n")
+    fh.write(f"  {key}{separator}{value}\n")
 
 
 def _dump_block(fh: TextIOBase, name: str, block: dict):

--- a/test/cone.deck
+++ b/test/cone.deck
@@ -121,8 +121,10 @@ begin:dist_fn
   resolution1 = 1
   resolution2 = 100
 
-  include_species:electron
-  include_species:proton
+  include_species:Electron
+  include_species:Proton
+
+  identify:Photon
 end:dist_fn
 
 
@@ -145,6 +147,8 @@ begin:dist_fn
   resolution2 = 100
   resolution3 = 100
 
-  include_species:electron
-  include_species:proton
+  include_species:Electron
+  include_species:Proton
+
+  identify:Photon
 end:dist_fn

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1,4 +1,4 @@
-from epydeck import loads, load
+import epydeck
 
 import pathlib
 
@@ -15,7 +15,7 @@ def test_basic_block():
     end:block
     """
 
-    data = loads(text)
+    data = epydeck.loads(text)
 
     expected = {
         "block": {
@@ -41,7 +41,7 @@ def test_repeated_line():
     end:block
     """
 
-    data = loads(text)
+    data = epydeck.loads(text)
 
     expected = {"block": {"a": 1, "b": 2, "c": [3, 4]}}
 
@@ -65,7 +65,7 @@ def test_repeated_block():
     end:block
     """
 
-    data = loads(text)
+    data = epydeck.loads(text)
 
     expected = {
         "block": {
@@ -81,14 +81,30 @@ def test_include_species():
     text = """
     begin:dist_fn
       a = 1
-      include_species: electron
-      include_species: proton
+      include_species:Electron
+      include_species:Proton
     end:dist_fn
     """
 
-    data = loads(text)
+    data = epydeck.loads(text)
 
-    expected = {"dist_fn": {"a": 1, "include_species": ["electron", "proton"]}}
+    expected = {"dist_fn": {"a": 1, "include_species": ["Electron", "Proton"]}}
+
+    assert expected == data
+
+
+def test_include_identify():
+    text = """
+    begin:dist_fn
+      a = 1
+      identify:Electron
+      identify:Proton
+    end:dist_fn
+    """
+
+    data = epydeck.loads(text)
+
+    expected = {"dist_fn": {"a": 1, "identify": ["Electron", "Proton"]}}
 
     assert expected == data
 
@@ -97,7 +113,7 @@ def test_read_file():
     filename = pathlib.Path(__file__).parent / "cone.deck"
 
     with open(filename) as f:
-        data = load(f)
+        data = epydeck.load(f)
 
     assert "control" in data
     assert "species" in data

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -1,5 +1,4 @@
-from epydeck import dumps, dump, load
-
+import epydeck
 from textwrap import dedent
 
 
@@ -28,7 +27,7 @@ def test_basic_block():
             "f": True,
         }
     }
-    result = dumps(deck)
+    result = epydeck.dumps(deck)
 
     assert expected == result
 
@@ -47,7 +46,7 @@ def test_repeated_line():
     )
 
     deck = {"block": {"a": 1, "b": 2, "c": [3, 4]}}
-    result = dumps(deck)
+    result = epydeck.dumps(deck)
 
     assert expected == result
 
@@ -78,7 +77,7 @@ def test_repeated_block():
             "second": {"name": "second", "a": 4, "b": 5, "c": 6},
         }
     }
-    result = dumps(deck)
+    result = epydeck.dumps(deck)
 
     assert expected == result
 
@@ -88,15 +87,33 @@ def test_include_species():
         """\
         begin:dist_fn
           a = 1
-          include_species: electron
-          include_species: proton
+          include_species:Electron
+          include_species:Proton
         end:dist_fn
     
         """
     )
 
-    deck = {"dist_fn": {"a": 1, "include_species": ["electron", "proton"]}}
-    result = dumps(deck)
+    deck = {"dist_fn": {"a": 1, "include_species": ["Electron", "Proton"]}}
+    result = epydeck.dumps(deck)
+
+    assert expected == result
+
+
+def test_include_identify():
+    expected = dedent(
+        """\
+        begin:dist_fn
+          a = 1
+          identify:Electron
+          identify:Proton
+        end:dist_fn
+    
+        """
+    )
+
+    deck = {"dist_fn": {"a": 1, "identify": ["Electron", "Proton"]}}
+    result = epydeck.dumps(deck)
 
     assert expected == result
 
@@ -119,9 +136,9 @@ def test_write_to_file(tmp_path):
 
     filename = tmp_path / "test.in"
     with open(filename, "w") as f:
-        dump(deck, f)
+        epydeck.dump(deck, f)
 
     with open(filename, "r") as f:
-        data = load(f)
+        data = epydeck.load(f)
 
     assert data == deck


### PR DESCRIPTION
- Add inclusion of `identify` keyword.
- Move special keywords (ones that use a `:` instead of `=` within a block) to top of file to account for multiple keywords and make it easier to add any additional keywords that may come up. 
- Modify `_dump_line` function to save keywords that use an equals to always include space before and after but not include a space when special keywords are used. e.g.
```bash
# Previously
identify: Photon

# Now
identify:Photon
```
