### PR TITLE
Add block ordering and block comment saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ import epydeck
 
 # Read from a file with `epydeck.load`
 with open(filename) as f:
-    deck = epydeck.load(f)
+    deck, block_order = epydeck.load(f)
 
 print(deck.keys())
 # dict_keys(['control', 'boundaries', 'constant', 'species', 'laser', 'output_global', 'output', 'dist_fn'])
+print(block_order)
+# ['control', 'boundaries', 'constant', 'species', 'laser', 'output_global', 'output', 'dist_fn']
 
 # Modify the deck as a usual python dict:
 deck["species"]["proton"]["charge"] = 2.0

--- a/src/epydeck/__init__.py
+++ b/src/epydeck/__init__.py
@@ -1,9 +1,11 @@
 from ast import literal_eval
-from io import TextIOBase, StringIO
 from collections import defaultdict
+from io import StringIO, TextIOBase
+from re import search
 
 # Specific deck keywords that use : instead of =
 special_keywords = ["include_species", "identify"]
+
 
 def _strip_comment(line: str) -> str:
     """Remove comments from line"""
@@ -26,14 +28,14 @@ def _join_lines(line: str, fh: TextIOBase) -> str:
 
 
 def _parse_block(line: str, fh: TextIOBase) -> dict:
-    """Parse a single options block into a dict"""
+    """Parse a single options block into a dict."""
     result = defaultdict(list)
-
     _, name = line.split(":")
+    comment_index = 0  # Track index for standalone comments
+    comment_indices = defaultdict(int)  # Track indices for each key
 
     for line in fh:
-        line = _strip_comment(line).strip()
-        line = _join_lines(line, fh)
+        line = _join_lines(line, fh).strip()
 
         # Handle empty lines
         if not line:
@@ -47,6 +49,21 @@ def _parse_block(line: str, fh: TextIOBase) -> dict:
                     f"Block name mismatch: expected '{name}', got '{end_name}'"
                 )
             break
+
+        # Handle standalone comments
+        if line.startswith("#"):
+            comment_key = f"comment_{comment_index}"
+            result[comment_key].append(line[1:].strip())
+            comment_index += 1
+            continue
+
+        # Handle inline comments (e.g., key = value # comment)
+        if "#" in line:
+            line, comment = line.split("#", 1)
+            line = line.strip()
+            comment = comment.strip()
+        else:
+            comment = None
 
         # Handle special keywords
         if any(line.lower().startswith(f"{keyword}:") for keyword in special_keywords):
@@ -62,22 +79,32 @@ def _parse_block(line: str, fh: TextIOBase) -> dict:
         except (ValueError, SyntaxError):
             value = value.strip()
 
+        # Convert T/F strings to booleans
         if value == "F":
             value = False
         elif value == "T":
             value = True
 
+        # Store the value
         result[key].append(value)
 
-    # Strip out useless lists
+        # Store the inline comment, if present
+        if comment:
+            comment_index = comment_indices[key]
+            comment_key = f"{key}_inline_comment_{comment_index}"
+            result[comment_key] = comment
+            comment_indices[key] += 1  # Increment index for this key
+
+    # Simplify lists to single values if only one item
     result = {k: v[0] if len(v) == 1 else v for k, v in result.items()}
 
     return name, result
 
 
-def load(fh: TextIOBase) -> dict:
-    """Load a whole EPOCH input deck into a Python dict"""
+def load(fh: TextIOBase) -> tuple[dict, list]:
+    """Load a whole EPOCH input deck into a Python dict and return block order"""
     result = defaultdict(dict)
+    block_order = []
 
     for line in fh:
         line = _strip_comment(line).strip()
@@ -90,59 +117,110 @@ def load(fh: TextIOBase) -> dict:
             block_name, block = _parse_block(line, fh)
 
             if "name" in block:
-                block = {block["name"]: block}
-
-            result[block_name] |= block
+                nested_block_name = block["name"]
+                block_order.append(f"{block_name}:{nested_block_name}")
+                block = {nested_block_name: block}
+                result[block_name] |= block
+            else:
+                if block_name not in result:
+                    result[block_name] = [block]
+                    block_order.append(f"{block_name}_0")
+                else:
+                    result[block_name].append(block)
+                    block_order.append(f"{block_name}_{len(result[block_name]) - 1}")
 
         if line.lower().startswith("import:"):
             # TODO
             continue
 
-    return dict(result)
+    # Simplify lists to single dict if only one item and update block_order
+    for key, value in result.items():
+        if isinstance(value, list) and len(value) == 1:
+            result[key] = value[0]
+            block_order[block_order.index(f"{key}_0")] = key
+
+    return dict(result), block_order
 
 
-def loads(text: str) -> dict:
+def loads(text: str) -> tuple[dict, list]:
     """Load an EPOCH deck from a string"""
 
     with StringIO(text) as fh:
         return load(fh)
 
 
-def _dump_line(fh: TextIOBase, key: str, value):
+def _dump_line(fh: TextIOBase, key: str, value, inline_comment: str = None):
+    """
+    Writes a single line to the file, handling special keywords and inline comments.
+    """
     separator = ":" if key in special_keywords else " = "
+
+    # Format booleans as T/F
     if isinstance(value, bool):
         value = "T" if value else "F"
-    fh.write(f"  {key}{separator}{value}\n")
+
+    # Write the line
+    line = f"  {key}{separator}{value}"
+    if inline_comment:
+        line += f" # {inline_comment}"
+    fh.write(f"{line}\n")
 
 
 def _dump_block(fh: TextIOBase, name: str, block: dict):
+    """Dump a single block to a file."""
     fh.write(f"begin:{name}\n")
 
     for key, values in block.items():
         if not isinstance(values, list):
             values = [values]
-        for value in values:
-            _dump_line(fh, key, value)
+
+        # Write standalone comments
+        if key.startswith("comment_"):
+            for i, value in enumerate(values):
+                fh.write(f"  # {value}\n")
+            continue
+
+        # Skip inline comments
+        if "inline_comment" in key:
+            continue
+
+        for i, value in enumerate(values):
+            # Check for associated inline comments
+            comment_key = f"{key}_inline_comment_{i}"
+            inline_comment = block.get(comment_key, None)
+
+            # Write the key-value pair with or without inline comment
+            _dump_line(fh, key, value, inline_comment)
 
     fh.write(f"end:{name}\n\n")
 
 
-def dump(deck: dict, fh: TextIOBase):
+def dump(deck: dict, fh: TextIOBase, block_order: list = None) -> None:
     """Write EPOCH deck to the open file object"""
+    block_order = block_order or list(deck.keys())
 
-    for name, block in deck.items():
+    for block_name in block_order:
+        block = deck.get(block_name, {})
+
+        if search(r"_\d$", block_name):
+            block_name, index = block_name.rsplit("_", 1)
+            block = deck[block_name][int(index)]
+        elif ":" in block_name:
+            block_name, nested_block_name = block_name.split(":")
+            block = deck[block_name][nested_block_name]
+
         # Is this one of multiple blocks?
         if isinstance(list(block.values())[0], dict):
             for subblock in block.values():
-                _dump_block(fh, name, subblock)
+                _dump_block(fh, block_name, subblock)
         else:
-            _dump_block(fh, name, block)
+            _dump_block(fh, block_name, block)
 
 
-def dumps(deck: dict) -> str:
+def dumps(deck: dict, block_order: list = None) -> str:
     """Write EPOCH deck to string"""
     fh = StringIO()
-    dump(deck, fh)
+    dump(deck, fh, block_order)
     return fh.getvalue()
 
 
@@ -155,7 +233,11 @@ def deep_update(deck: dict, *deck_patches: dict) -> dict:
     updated_deck = deck.copy()
     for deck_patch in deck_patches:
         for k, v in deck_patch.items():
-            if k in updated_deck and isinstance(updated_deck[k], dict) and isinstance(v, dict):
+            if (
+                k in updated_deck
+                and isinstance(updated_deck[k], dict)
+                and isinstance(v, dict)
+            ):
                 updated_deck[k] = deep_update(updated_deck[k], v)
             else:
                 updated_deck[k] = v

--- a/test/cone.deck
+++ b/test/cone.deck
@@ -2,7 +2,7 @@ begin:control
   nx = 250
   ny = 250
   nz = 250
-  nparticles = nx * ny * nz * 1.123
+  nparticles = nx * ny * nz * 1.123 # inline with the number density
 
   # Final time of simulation
   t_end = 50 * femto
@@ -26,6 +26,10 @@ begin:boundaries
   bc_z_max = periodic
 end:boundaries
 
+begin:control
+  # Second control block
+  nx = 250
+end:control
 
 begin:constant
   lambda = 1.06 * micron

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1,6 +1,6 @@
-import epydeck
-
 import pathlib
+
+import epydeck
 
 
 def test_basic_block():
@@ -15,7 +15,7 @@ def test_basic_block():
     end:block
     """
 
-    data = epydeck.loads(text)
+    data, block_order = epydeck.loads(text)
 
     expected = {
         "block": {
@@ -27,8 +27,80 @@ def test_basic_block():
             "f": True,
         }
     }
+    expected_block_order = ["block"]
 
     assert expected == data
+    assert expected_block_order == block_order
+
+
+def test_basic_block_with_name():
+    text = """
+    begin:block
+      name = first
+      a = 1
+      b = 2
+      c = 3
+    end:block
+    """
+
+    data, block_order = epydeck.loads(text)
+
+    expected = {"block": {"first": {"name": "first", "a": 1, "b": 2, "c": 3}}}
+    expected_block_order = ["block:first"]
+
+    assert expected == data
+    assert expected_block_order == block_order
+
+
+def test_basic_block_with_comment():
+    text = """
+    begin:block
+      a = 1
+      # This is a comment
+      b = 2
+      c = 3
+    end:block
+    """
+
+    data, block_order = epydeck.loads(text)
+
+    expected = {
+        "block": {
+            "a": 1,
+            "comment_0": "This is a comment",
+            "b": 2,
+            "c": 3,
+        }
+    }
+    expected_block_order = ["block"]
+
+    assert expected == data
+    assert expected_block_order == block_order
+
+
+def test_basic_block_with_inline_comment():
+    text = """
+    begin:block
+      a = 1
+      b = 2 # This is a comment
+      c = 3
+    end:block
+    """
+
+    data, block_order = epydeck.loads(text)
+
+    expected = {
+        "block": {
+            "a": 1,
+            "b": 2,
+            "b_inline_comment_0": "This is a comment",
+            "c": 3,
+        }
+    }
+    expected_block_order = ["block"]
+
+    assert expected == data
+    assert expected_block_order == block_order
 
 
 def test_repeated_line():
@@ -41,7 +113,7 @@ def test_repeated_line():
     end:block
     """
 
-    data = epydeck.loads(text)
+    data, _ = epydeck.loads(text)
 
     expected = {"block": {"a": 1, "b": 2, "c": [3, 4]}}
 
@@ -65,7 +137,7 @@ def test_repeated_block():
     end:block
     """
 
-    data = epydeck.loads(text)
+    data, block_order = epydeck.loads(text)
 
     expected = {
         "block": {
@@ -73,8 +145,10 @@ def test_repeated_block():
             "second": {"name": "second", "a": 4, "b": 5, "c": 6},
         }
     }
+    expected_block_order = ["block:first", "block:second"]
 
     assert expected == data
+    assert expected_block_order == block_order
 
 
 def test_include_species():
@@ -86,7 +160,7 @@ def test_include_species():
     end:dist_fn
     """
 
-    data = epydeck.loads(text)
+    data, _ = epydeck.loads(text)
 
     expected = {"dist_fn": {"a": 1, "include_species": ["Electron", "Proton"]}}
 
@@ -102,7 +176,7 @@ def test_include_identify():
     end:dist_fn
     """
 
-    data = epydeck.loads(text)
+    data, _ = epydeck.loads(text)
 
     expected = {"dist_fn": {"a": 1, "identify": ["Electron", "Proton"]}}
 
@@ -113,9 +187,27 @@ def test_read_file():
     filename = pathlib.Path(__file__).parent / "cone.deck"
 
     with open(filename) as f:
-        data = epydeck.load(f)
+        data, block_order = epydeck.load(f)
 
     assert "control" in data
+    assert len(data["control"]) == 2
     assert "species" in data
     assert "proton" in data["species"]
     assert "electron" in data["species"]
+
+    expected_block_order = [
+        "control_0",
+        "boundaries",
+        "control_1",
+        "constant",
+        "species:proton",
+        "species:electron",
+        "laser",
+        "output_global",
+        "output:normal",
+        "output:large",
+        "dist_fn:x_px",
+        "dist_fn:x_px_py",
+    ]
+
+    assert expected_block_order == block_order


### PR DESCRIPTION
Researchers have requested the ability to store multiple blocks with similar names (e.g. multiple `control` blocks as seen in the updated `cone.deck`). There has also been significant interest in storing newline and inline comments from a block. The user experience remains mostly unchanged unless blocks contain comments. The only visible difference is that the `loads` function now returns a tuple instead of just the dictionary.

### Handling of Blocks with the Same Name 
Blocks that share the same name but do not have a `name` parameter are now stored as separate entries in an array, rather than being merged into the same dictionary.
  
### `loads` and `load` Function Updates
- The `loads` (and consequently `load`) functions now return a tuple containing both the deck in dictionary format and a `block_order` list. 
- The `block_order` maintains the order in which blocks are loaded. It uses the following notation:
  - `{block_name}`: For blocks with a unique name.
  - `{block_name}:{sub_block}`: For blocks that have the same name and contain a `name` field (sub-blocks).
  - `{block_name}_{i}`: For blocks with the same name but no `name` field, where `i` is a zero-based index.

### Comment Handling
Comments within blocks are now stored using the following notation:
- **Standalone comments** (on new lines) are indexed as `comment_{i}` where `i` starts at 0.
- **Inline comments** (after a key-value pair) are indexed as `{key}_inline_comment_{i}` where `key` is the key and `i` starts at 0.

### Testing:
Tests have been updated to reflect the new behaviour.