### PR TITLE
Fix edge case in special keywords when spaces are present

### DIFF
--- a/src/epydeck/__init__.py
+++ b/src/epydeck/__init__.py
@@ -1,6 +1,7 @@
 from ast import literal_eval
 from io import TextIOBase, StringIO
 from collections import defaultdict
+import re
 
 # Specific deck keywords that use : instead of =
 special_keywords = ["include_species", "identify"]
@@ -49,7 +50,7 @@ def _parse_block(line: str, fh: TextIOBase) -> dict:
             break
 
         # Handle special keywords
-        if any(line.lower().startswith(f"{keyword}:") for keyword in special_keywords):
+        if any(re.match(rf"^{re.escape(keyword)}\s*:", line.lower()) for keyword in special_keywords):
             separator = ":"
         else:
             separator = "="

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -119,3 +119,19 @@ def test_read_file():
     assert "species" in data
     assert "proton" in data["species"]
     assert "electron" in data["species"]
+
+
+def test_include_identify_with_spaces():
+    text = """
+    begin:dist_fn
+      a = 1
+      identify: Electron
+      identify : Proton
+    end:dist_fn
+    """
+
+    data = epydeck.loads(text)
+
+    expected = {"dist_fn": {"a": 1, "identify": ["Electron", "Proton"]}}
+
+    assert expected == data


### PR DESCRIPTION
Fixes issue with spaces in being present in `special_keywords` causing separator to not be chosen correctly.

Fixes #10 